### PR TITLE
Fix a compile error in opaque.c

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout repository
@@ -52,6 +52,6 @@ jobs:
        sudo apt-get update
        sudo apt-get install python libsodium-dev pkgconf
        make bin libopaque.so tests/opaque
-     
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # libopaque
 
-This library implements OPAQUE protocol as proposed by the IETF CFRG in
-https://github.com/cfrg/draft-irtf-cfrg-opaque
-
+This library implements the OPAQUE protocol as proposed by the IETF CFRG in
+https://github.com/cfrg/draft-irtf-cfrg-opaque.
 
 ## Installing
 
-Install `python`, `libsodium`  and `libsodium-dev` using your operating system provided
-package management. 
+Install `python`, `libsodium` and `libsodium-dev` using your operating system's
+package manager.
 
 Building everything should (hopefully) be quite simple afterwards:
 
@@ -19,39 +18,45 @@ make
 
 ## OPAQUE API
 
-The API is described in the header file: src/opaque.h.
+The API is described in the header file:
+[`src/opaque.h`](https://github.com/stef/libopaque/blob/master/src/opaque.h).
 
 The library implements the OPAQUE protocol with the following deviations:
 
- 0. does not implement any persistence/lookup functionality.
- 1. instead of HMQV (which is patented) it implements a Triple-DH instead.
- 2. it implements "user iterated hashing" from page 29 of the paper
- 3. additionally implements a variant where U secrets never hit S unprotected
+0. It does not implement any persistence/lookup functionality.
+1. Instead of HMQV (which is patented), it implements a Triple-DH.
+2. It implements "user iterated hashing" from page 29 of the paper.
+3. It additionally implements a variant where U secrets never hit S
+   unprotected.
 
-For more information please see the IETF CFRG specification at
-https://github.com/cfrg/draft-irtf-cfrg-opaque/blob/master/draft-irtf-cfrg-opaque.md
-original paper (doc/opaque.pdf) and the `src/tests/opaque-test.c` example file.
+For more information, see the IETF CFRG specification at
+https://github.com/cfrg/draft-irtf-cfrg-opaque/blob/master/draft-irtf-cfrg-opaque.md,
+the original paper
+([`doc/opaque.pdf`](https://github.com/stef/libopaque/blob/master/doc/opaque.pdf))
+and the
+[`src/tests/opaque-test.c`](https://github.com/stef/libopaque/blob/master/src/tests/opaque-test.c)
+example file.
 
 ## OPAQUE Parameters
 
-Currently all parameters are hardcoded, but there's nothing stoping you
-and set stronger values for the password hash.
+Currently all parameters are hardcoded, but there is nothing stopping you from
+setting stronger values for the password hash.
 
 ### The Curve
 
-This OPAQUE implementation is based on libsodiums ristretto25519 curve,
-This means currently all keys are 32 byte long.
+This OPAQUE implementation is based on libsodium's ristretto25519 curve. This
+means currently all keys are 32 bytes long.
 
-### Other Crypto building blocks
+### Other Crypto Building Blocks
 
-This OPAQUE implementation relies on libsodium as a dependency to
-provide all other cryptographic primitives:
+This OPAQUE implementation relies on libsodium as a dependency to provide all
+other cryptographic primitives:
 
-   - crypto_pwhash[1] uses the Argon2 function with
-     `crypto_pwhash_OPSLIMIT_INTERACTIVE`,
-     `crypto_pwhash_MEMLIMIT_INTERACTIVE` as security parameters.
-   - randombytes attempts to use the cryptographic random source of
-     the underlying operating system[2]
+- `crypto_pwhash`<sup>[1]</sup> uses the Argon2 function with
+  `crypto_pwhash_OPSLIMIT_INTERACTIVE` and
+  `crypto_pwhash_MEMLIMIT_INTERACTIVE` as security parameters.
+- `randombytes` attempts to use the cryptographic random source of
+  the underlying operating system<sup>[2]</sup>.
 
-[1] https://download.libsodium.org/doc/password_hashing/the_argon2i_function
-[2] https://download.libsodium.org/doc/generating_random_data
+[1]: https://doc.libsodium.org/password_hashing/default_phf
+[2]: https://download.libsodium.org/doc/generating_random_data

--- a/src/opaque.c
+++ b/src/opaque.c
@@ -826,7 +826,7 @@ int opaque_Register(const uint8_t *pw, const uint16_t pwlen,
 
 #ifdef TRACE
   dump((uint8_t*) cfg,2, "cfg ");
-  fprintf(stderr, "cfg sku: %d, pku:%d, pks:%d, idu:%d, ids:%d\n", cfg->sku, cfg->pku, cfg->pks, cfg->idu, cfg->ids);
+  fprintf(stderr, "cfg skU: %d, pkU:%d, pkS:%d, idU:%d, idS:%d\n", cfg->skU, cfg->pkU, cfg->pkS, cfg->idU, cfg->idS);
   dump(ids->idU, ids->idU_len,"idU ");
   dump(ids->idS, ids->idS_len,"idS ");
   fprintf(stderr,"clrenv_len: %d\n", ClrEnv_len);


### PR DESCRIPTION
There was a compile error in opaque.c when compiling on Ubuntu 20.04.1. See the commit message for more details.

I also updated the README.md.