### PR TITLE
make should produce a release build by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ other cryptographic primitives:
 
 [1]: https://doc.libsodium.org/password_hashing/default_phf
 [2]: https://download.libsodium.org/doc/generating_random_data
+
+### Debugging
+
+To aid in debugging and testing, there are two macros available:
+
+| Macro      | Description                                       |
+| ---------- | ------------------------------------------------- |
+| `TRACE`    | outputs extra information to stderr for debugging |
+| `NORANDOM` | removes randomness for deterministic results      |
+
+To use these macros, specify the `DEFINES` Makefile variable when calling
+`make`:
+
+```
+$ make DEFINES='-DTRACE -DNORANDOM' clean libopaque.so tests
+$ LD_LIBRARY_PATH=. ./tests/opaque
+```

--- a/src/makefile
+++ b/src/makefile
@@ -13,9 +13,9 @@ else
 	CFLAGS+= -DHAVE_SODIUM_HKDF=1
 endif
 
-all: bin libopaque.so tests
+all: bin libopaque.$(SOEXT) tests$(EXT)
 
-tests$(EXT): tests/opaque$(EXT) tests/opaque-munit
+tests$(EXT): tests/opaque$(EXT) tests/opaque-munit$(EXT)
 
 libopaque.$(SOEXT): common.o opaque.o $(EXTRA_OBJECTS)
 	$(CC) -shared -fpic $(CFLAGS) -o libopaque.$(SOEXT) $^ $(LDFLAGS)
@@ -26,7 +26,7 @@ tests/opaque$(EXT): tests/opaque-test.c libopaque.$(SOEXT)
 tests/opaque-munit$(EXT): tests/opaque_munit.c libopaque.$(SOEXT)
 	$(CC) $(CFLAGS) -o tests/munit-opaque$(EXT) tests/munit/munit.c tests/opaque_munit.c -L. -lopaque $(LDFLAGS)
 
-test: tests/opaque-munit$(EXT)
+test: tests/opaque-munit
 	LD_PRELOAD=./libopaque.so ./tests/munit-opaque --fatal-failures
 
 install: $(PREFIX)/lib/libopaque.$(SOEXT) $(PREFIX)/include/opaque.h

--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,8 @@
 PREFIX?=/usr/local
 LIBS=-lsodium
-CFLAGS=-march=native -Wall -fPIC -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -fstack-clash-protection -fcf-protection=full -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,defs -Wl,-z,relro -ftrapv -Wl,-z,noexecstack -DTRACE -DNORANDOM
+DEFINES=
+#DEFINES=-DTRACE -DNORANDOM
+CFLAGS=-march=native -Wall -fPIC -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -fstack-clash-protection -fcf-protection=full -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,defs -Wl,-z,relro -ftrapv -Wl,-z,noexecstack $(DEFINES)
 LDFLAGS=-g $(LIBS)
 CC=gcc
 SOEXT=so


### PR DESCRIPTION
I brought over @stef's `makefile` change from https://github.com/stef/libopaque/commit/871f64d39e585b44d16c0e950bcb546053937a19 and made modifications.

@stef, should `-fPIC` and `-fpic` both be specified in `CFLAGS`?