### PR TITLE
Allow systems that do not support mlock to use libopaque

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -23,3 +23,66 @@ void a_randomscalar(unsigned char* buf) {
 }
 #endif // NORANDOM
 
+#ifdef __EMSCRIPTEN__
+
+/*
+ * The following is from
+ * https://github.com/jedisct1/libsodium/blob/1.0.18/src/libsodium/sodium/utils.c .
+ *
+ * int
+ * sodium_mlock(void *const addr, const size_t len)
+ * {
+ * #if defined(MADV_DONTDUMP) && defined(HAVE_MADVISE)
+ *     (void) madvise(addr, len, MADV_DONTDUMP);
+ * #endif
+ * #ifdef HAVE_MLOCK
+ *     return mlock(addr, len);
+ * #elif defined(WINAPI_DESKTOP)
+ *     return -(VirtualLock(addr, len) == 0);
+ * #else
+ *     errno = ENOSYS;
+ *     return -1;
+ * #endif
+ * }
+ *
+ * When executing code compiled with Empscripten to create JavaScript bindings,
+ * only the last part starting with "errno = ENOSYS" executes. ENOSYS means
+ * "Function not implemented". libopaque checks the return value of sodium_mlock.
+ * We do not want to fail, so let us just return 0.
+ */
+int opaque_mlock(void *const addr, const size_t len) {
+  return 0;
+}
+
+/*
+ * The following is from
+ * https://github.com/jedisct1/libsodium/blob/1.0.18/src/libsodium/sodium/utils.c .
+ *
+ * int
+ * sodium_munlock(void *const addr, const size_t len)
+ * {
+ *     sodium_memzero(addr, len);
+ * #if defined(MADV_DODUMP) && defined(HAVE_MADVISE)
+ *     (void) madvise(addr, len, MADV_DODUMP);
+ * #endif
+ * #ifdef HAVE_MLOCK
+ *     return munlock(addr, len);
+ * #elif defined(WINAPI_DESKTOP)
+ *     return -(VirtualUnlock(addr, len) == 0);
+ * #else
+ *     errno = ENOSYS;
+ *     return -1;
+ * #endif
+ * }
+ *
+ * When executing code compiled with Empscripten to create JavaScript bindings,
+ * only the sodium_memzero line and the lines starting at "errno = ENOSYS"
+ * execute. ENOSYS means "Function not implemented". libopaque checks the return
+ * value of sodium_mlock. We do not want to fail, so let us return 0.
+ */
+int opaque_munlock(void *const addr, const size_t len) {
+  sodium_memzero(addr, len);
+  return 0;
+}
+
+#endif // __EMSCRIPTEN__

--- a/src/common.h
+++ b/src/common.h
@@ -20,4 +20,17 @@ void a_randomscalar(unsigned char* buf);
 #define randombytes a_randombytes
 #endif
 
+#ifdef __EMSCRIPTEN__
+// Per
+// https://emscripten.org/docs/compiling/Building-Projects.html#detecting-emscripten-in-preprocessor,
+// "The preprocessor define __EMSCRIPTEN__ is always defined when compiling
+// programs with Emscripten". For why we are replacing sodium_m(un)?lock, see
+// common.c for more details.
+#include <sodium.h>
+int opaque_mlock(void *const addr, const size_t len);
+int opaque_munlock(void *const addr, const size_t len);
+#define sodium_mlock opaque_mlock
+#define sodium_munlock opaque_munlock
+#endif
+
 #endif //COMMON_H


### PR DESCRIPTION
I have been working on JavaScript bindings for libopaque: https://github.com/creemama/libopaque/tree/javascript-bindings/js .
`sodium_mlock` and `sodium_munlock` are not fully supported when libopaque is compiled using Emscripten to create the JavaScript bindings.

I could think of two ways to handle this.

(1) The first is this commit where we introduce `opaque_mlock` and `opaque_munlock` to wrap `sodium_mlock` and `sodium_munlock`. When compiled using `EMSCRIPTEN`, then we disregard `sodium_mlock` and `sodium_munlock` failures.

(2) The second is this commit (https://github.com/creemama/libopaque/commit/294bd6f4b6d167333f65c68dbe304368db610d06) where we no longer check if `sodium_mlock` or `sodium_munlock` returns successfully. This seems plausible since `opaque.c` does not check the return value of `sodium_mlock` or `sodium_munlock` all the time.

@stef, what do you think? Is there another possibility I am not thinking of?