### PR TITLE
Match the variable names of the current IETF CFRG draft

### DIFF
--- a/src/opaque.h
+++ b/src/opaque.h
@@ -127,11 +127,11 @@ typedef struct {
 
    @param [in] pwdU - the users password
    @param [in] pwdU_len - length of the users password
-   @param [in] key - a key to be used for domain separation in the
+   @param [in] info - a key to be used for domain separation in the
         final hash of the OPRF. if set to NULL then the default is
         "RFCXXXX" - TODO set XXXX to the real value when the rfc is
         published.
-   @param [in] key_len - length of the key, ignored if key is NULL
+   @param [in] info_len - length of the info, ignored if info is NULL
    @param [in] skS - in case of global server keys this is the servers
         private key, should be set to NULL if per/user keys are to be
         generated
@@ -148,7 +148,7 @@ typedef struct {
         encrypt/authenticate additional data.
    @return the function returns 0 if everything is correct
  */
-int opaque_Register(const uint8_t *pwdU, const uint16_t pwdU_len, const uint8_t *key, const uint16_t key_len, const uint8_t skS[crypto_scalarmult_SCALARBYTES], const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_Register(const uint8_t *pwdU, const uint16_t pwdU_len, const uint8_t *info, const uint16_t info_len, const uint8_t skS[crypto_scalarmult_SCALARBYTES], const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    This function initiates a new OPAQUE session, is the same as the
@@ -205,10 +205,10 @@ int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC
    @param [in] resp - the response sent from the server running opaque_CreateCredentialResponse()
    @param [in] sec - the private sec output of the client initiating
    this instantiation of this protocol using opaque_CreateCredentialRequest()
-   @param [in] key - an value to be used as key during the final hashing
+   @param [in] info - a value to be used as a key do during the final hashing
    of the OPRF, the rfc specifies this as 'RFCXXXX' but can be any other
    local secret amending the password typed in in the first step.
-   @param [in] key_len - the length of the previous param key
+   @param [in] info_len - the length of the previous param info
    @param [in] pkS - if cfg.pkS == NotPackaged pkS *must* be supplied here, otherwise it must be NULL
    @param [in] cfg - the configuration of the envelope secret and cleartext part
    @param [in] infos - various extra (unspecified) protocol information
@@ -224,7 +224,7 @@ int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC
    material not stored directly in the envelope
    @return the function returns 0 if the protocol is executed correctly
 */
-int opaque_RecoverCredentials(const uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+envU_len*/], const uint8_t sec[OPAQUE_USER_SESSION_SECRET_LEN/*+pwdU_len*/], const uint8_t *key, const uint16_t key_len, const uint8_t pkS[crypto_scalarmult_BYTES], const Opaque_PkgConfig *cfg, const Opaque_App_Infos *infos, Opaque_Ids *ids, uint8_t *sk, uint8_t authU[crypto_auth_hmacsha256_BYTES], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_RecoverCredentials(const uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+envU_len*/], const uint8_t sec[OPAQUE_USER_SESSION_SECRET_LEN/*+pwdU_len*/], const uint8_t *info, const uint16_t info_len, const uint8_t pkS[crypto_scalarmult_BYTES], const Opaque_PkgConfig *cfg, const Opaque_App_Infos *infos, Opaque_Ids *ids, uint8_t *sk, uint8_t authU[crypto_auth_hmacsha256_BYTES], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    Explicit User Authentication.
@@ -324,9 +324,9 @@ int opaque_Create1kRegistrationResponse(const uint8_t M[crypto_core_ristretto255
    is run by the user, taking as input the context sec that was an
    output of the user running opaque_CreateRegistrationRequest(), and the
    output pub from the server of opaque_CreateRegistrationResponse().
-   The key parameter can be used as an extra contribution to the
+   The info parameter can be used as an extra contribution to the
    derivation of the rwdU by means of being used as a key to the final
-   hash, if not specified it uses the value specified by the rfc. The
+   hash. If not specified, it uses the value specified by the rfc. The
    result of this is the value rec which should be passed for the last
    step to the server.
 
@@ -334,10 +334,10 @@ int opaque_Create1kRegistrationResponse(const uint8_t M[crypto_core_ristretto255
    should be sanitized after usage.
    @param [in] pub - response from the server running
    opaque_CreateRegistrationResponse()
-   @param [in] key - an value to be used as key during the final hashing
+   @param [in] info - a value to be used as a key during the final hashing
    of the OPRF, the rfc specifies this as 'RFCXXXX' but can be any other
    local secret amending the password typed in in the first step.
-   @param [in] key_len - the length of the previous param key
+   @param [in] info_len - the length of the previous param info
    @param [in] cfg - the configuration of the envelope secret and cleartext part
    @param [in] ids - if ids are to be packed in the envelope - as given by
    the cfg param
@@ -350,7 +350,7 @@ int opaque_Create1kRegistrationResponse(const uint8_t M[crypto_core_ristretto255
 
    @return the function returns 0 if everything is correct.
  */
-int opaque_FinalizeRequest(const uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN/*+pwdU_len*/], const uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN], const uint8_t *key, const uint16_t key_len, const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_FinalizeRequest(const uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN/*+pwdU_len*/], const uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN], const uint8_t *info, const uint16_t info_len, const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    Final Registration step - server adds own info to the record to be stored.

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -15,7 +15,7 @@
 
 #define OPAQUE_USER_RECORD_LEN (                       \
    /* k_s */ crypto_core_ristretto255_SCALARBYTES+     \
-   /* p_s */ crypto_scalarmult_SCALARBYTES+            \
+   /* skS */ crypto_scalarmult_SCALARBYTES+            \
    /* pkU */ crypto_scalarmult_BYTES+                  \
    /* pkS */ crypto_scalarmult_BYTES+                  \
    /* env_len */ sizeof(uint32_t))
@@ -48,7 +48,7 @@
    /* pkS */ crypto_scalarmult_BYTES)
 
 #define OPAQUE_REGISTER_SECRET_LEN (                   \
-   /* p_s */ crypto_scalarmult_SCALARBYTES+            \
+   /* skS */ crypto_scalarmult_SCALARBYTES+            \
    /* k_s */ crypto_core_ristretto255_SCALARBYTES)
 
 #define OPAQUE_SERVER_AUTH_CTX_LEN ( \

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -33,7 +33,7 @@
    /* pwdU_len */ sizeof(uint16_t))
 
 #define OPAQUE_SERVER_SESSION_LEN (                    \
-   /* beta */ crypto_core_ristretto255_BYTES+          \
+   /* Z */ crypto_core_ristretto255_BYTES+             \
    /* X_s */ crypto_scalarmult_BYTES+                  \
    /* nonceS */ OPAQUE_NONCE_BYTES+                    \
    /* auth */ crypto_auth_hmacsha256_BYTES+            \
@@ -44,7 +44,7 @@
    /* pwdU_len */ sizeof(uint16_t))                    \
 
 #define OPAQUE_REGISTER_PUBLIC_LEN (                   \
-   /* beta */ crypto_core_ristretto255_BYTES+          \
+   /* Z */ crypto_core_ristretto255_BYTES+             \
    /* pkS */ crypto_scalarmult_BYTES)
 
 #define OPAQUE_REGISTER_SECRET_LEN (                   \

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -17,7 +17,7 @@
    /* k_s */ crypto_core_ristretto255_SCALARBYTES+     \
    /* p_s */ crypto_scalarmult_SCALARBYTES+            \
    /* P_u */ crypto_scalarmult_BYTES+                  \
-   /* P_s */ crypto_scalarmult_BYTES+                  \
+   /* pkS */ crypto_scalarmult_BYTES+                  \
    /* env_len */ sizeof(uint32_t))
 
 #define OPAQUE_USER_SESSION_PUBLIC_LEN (               \
@@ -45,7 +45,7 @@
 
 #define OPAQUE_REGISTER_PUBLIC_LEN (                   \
    /* beta */ crypto_core_ristretto255_BYTES+          \
-   /* P_s */ crypto_scalarmult_BYTES)
+   /* pkS */ crypto_scalarmult_BYTES)
 
 #define OPAQUE_REGISTER_SECRET_LEN (                   \
    /* p_s */ crypto_scalarmult_SCALARBYTES+            \

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -21,7 +21,7 @@
    /* envU_len */ sizeof(uint32_t))
 
 #define OPAQUE_USER_SESSION_PUBLIC_LEN (               \
-   /* alpha */  crypto_core_ristretto255_BYTES+        \
+   /* M */  crypto_core_ristretto255_BYTES+            \
    /* X_u */    crypto_scalarmult_BYTES+               \
    /* nonceU */ OPAQUE_NONCE_BYTES)
 
@@ -29,7 +29,7 @@
    /* r */      crypto_core_ristretto255_SCALARBYTES+  \
    /* x_u */    crypto_scalarmult_SCALARBYTES+         \
    /* nonceU */ OPAQUE_NONCE_BYTES+                    \
-   /* alpha */  crypto_core_ristretto255_BYTES+        \
+   /* M */  crypto_core_ristretto255_BYTES+            \
    /* pwdU_len */ sizeof(uint16_t))
 
 #define OPAQUE_SERVER_SESSION_LEN (                    \
@@ -259,37 +259,37 @@ int opaque_UserAuth(const uint8_t sec[OPAQUE_SERVER_AUTH_CTX_LEN], const uint8_t
 /**
    Initial step to start registering a new user/client with the server.
    The user inputs its password pwdU, and receives a secret context sec
-   and a blinded value alpha as output. sec should be protected until
-   step 3 of this registration protocol and the value alpha should be
+   and a blinded value M as output. sec should be protected until
+   step 3 of this registration protocol and the value M should be
    passed to the server.
    @param [in] pwdU - the users password
    @param [in] pwdU_len - length of the users password
    @param [out] sec - a secret context needed for the 3rd step in this
    registration protocol - this needs to be protected and sanitized
    after usage.
-   @param [out] alpha - the blinded hashed password as per the OPRF,
+   @param [out] M - the blinded hashed password as per the OPRF,
    this needs to be sent to the server together with any other
    important and implementation specific info such as user/client id,
    envelope configuration etc.
    @return the function returns 0 if everything is correct.
  */
-int opaque_CreateRegistrationRequest(const uint8_t *pwdU, const uint16_t pwdU_len, uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len], uint8_t alpha[crypto_core_ristretto255_BYTES]);
+int opaque_CreateRegistrationRequest(const uint8_t *pwdU, const uint16_t pwdU_len, uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len], uint8_t M[crypto_core_ristretto255_BYTES]);
 
 /**
    Server evaluates OPRF and creates a user-specific public/private keypair
 
-   The server receives alpha from the users invocation of its
+   The server receives M from the users invocation of its
    opaque_CreateRegistrationRequest() function, it outputs a value sec
    which needs to be protected until step 4 by the server. This
    function also outputs a value pub which needs to be passed to the
    user.
-   @param [in] alpha - the blinded password as per the OPRF.
+   @param [in] M - the blinded password as per the OPRF.
    @param [out] sec - the private key and the OPRF secret of the server.
    @param [out] pub - the evaluated OPRF and pubkey of the server to
    be passed to the client into opaque_FinalizeRequest()
    @return the function returns 0 if everything is correct.
  */
-int opaque_CreateRegistrationResponse(const uint8_t alpha[crypto_core_ristretto255_BYTES], uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN]);
+int opaque_CreateRegistrationResponse(const uint8_t M[crypto_core_ristretto255_BYTES], uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN]);
 
 /**
    2nd step of registration: Server evaluates OPRF - Global Server Key Version
@@ -302,19 +302,19 @@ int opaque_CreateRegistrationResponse(const uint8_t alpha[crypto_core_ristretto2
    server secret.
 
    This function is called CreateRegistrationResponse in the rfc.
-   The server receives alpha from the users invocation of its
+   The server receives M from the users invocation of its
    opaque_CreateRegistrationRequest() function, it outputs a value sec
    which needs to be protected until step 4 by the server. This
    function also outputs a value pub which needs to be passed to the
    user.
-   @param [in] alpha - the blinded password as per the OPRF.
+   @param [in] M - the blinded password as per the OPRF.
    @param [in] pkS - the servers long-term pubkey
    @param [out] sec - the private key and the OPRF secret of the server.
    @param [out] pub - the evaluated OPRF and pubkey of the server to
    be passed to the client into opaque_FinalizeRequest()
    @return the function returns 0 if everything is correct.
  */
-int opaque_Create1kRegistrationResponse(const uint8_t alpha[crypto_core_ristretto255_BYTES], const uint8_t pkS[crypto_scalarmult_BYTES], uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN]);
+int opaque_Create1kRegistrationResponse(const uint8_t M[crypto_core_ristretto255_BYTES], const uint8_t pkS[crypto_scalarmult_BYTES], uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN]);
 
 /**
    Client finalizes registration by concluding the OPRF, generating

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -325,7 +325,7 @@ int opaque_Create1kRegistrationResponse(const uint8_t M[crypto_core_ristretto255
    output of the user running opaque_CreateRegistrationRequest(), and the
    output pub from the server of opaque_CreateRegistrationResponse().
    The key parameter can be used as an extra contribution to the
-   derivation of the rwd by means of being used as a key to the final
+   derivation of the rwdU by means of being used as a key to the final
    hash, if not specified it uses the value specified by the rfc. The
    result of this is the value rec which should be passed for the last
    step to the server.

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -14,7 +14,7 @@
 #define OPAQUE_ENVELOPE_META_LEN (2*crypto_hash_sha256_BYTES + 2*sizeof(uint16_t))
 
 #define OPAQUE_USER_RECORD_LEN (                       \
-   /* k_s */ crypto_core_ristretto255_SCALARBYTES+     \
+   /* kU */ crypto_core_ristretto255_SCALARBYTES+      \
    /* skS */ crypto_scalarmult_SCALARBYTES+            \
    /* pkU */ crypto_scalarmult_BYTES+                  \
    /* pkS */ crypto_scalarmult_BYTES+                  \
@@ -49,7 +49,7 @@
 
 #define OPAQUE_REGISTER_SECRET_LEN (                   \
    /* skS */ crypto_scalarmult_SCALARBYTES+            \
-   /* k_s */ crypto_core_ristretto255_SCALARBYTES)
+   /* kU */ crypto_core_ristretto255_SCALARBYTES)
 
 #define OPAQUE_SERVER_AUTH_CTX_LEN ( \
   crypto_auth_hmacsha256_KEYBYTES +  \

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -18,7 +18,7 @@
    /* skS */ crypto_scalarmult_SCALARBYTES+            \
    /* pkU */ crypto_scalarmult_BYTES+                  \
    /* pkS */ crypto_scalarmult_BYTES+                  \
-   /* env_len */ sizeof(uint32_t))
+   /* envU_len */ sizeof(uint32_t))
 
 #define OPAQUE_USER_SESSION_PUBLIC_LEN (               \
    /* alpha */  crypto_core_ristretto255_BYTES+        \
@@ -37,7 +37,7 @@
    /* X_s */ crypto_scalarmult_BYTES+                  \
    /* nonceS */ OPAQUE_NONCE_BYTES+                    \
    /* auth */ crypto_auth_hmacsha256_BYTES+            \
-   /* env_len */ sizeof(uint32_t))
+   /* envU_len */ sizeof(uint32_t))
 
 #define OPAQUE_REGISTER_USER_SEC_LEN (                 \
    /* r */ crypto_core_ristretto255_SCALARBYTES+       \
@@ -148,7 +148,7 @@ typedef struct {
         encrypt/authenticate additional data.
    @return the function returns 0 if everything is correct
  */
-int opaque_Register(const uint8_t *pwdU, const uint16_t pwdU_len, const uint8_t *key, const uint16_t key_len, const uint8_t skS[crypto_scalarmult_SCALARBYTES], const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+env_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_Register(const uint8_t *pwdU, const uint16_t pwdU_len, const uint8_t *key, const uint16_t key_len, const uint8_t skS[crypto_scalarmult_SCALARBYTES], const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    This function initiates a new OPAQUE session, is the same as the
@@ -179,8 +179,8 @@ int opaque_CreateCredentialRequest(const uint8_t *pwdU, const uint16_t pwdU_len,
    @param [in] ids - the id if the client and server
    @param [in] infos - various extra (unspecified) protocol information as recommended by the rfc.
    @param [out] resp - servers response to be sent to the client where
-   it is used as input into opaque_RecoverCredentials() - caller must allocate including env_len: e.g.:
-   unsigned char resp[OPAQUE_SERVER_SESSION_LEN+env_len];
+   it is used as input into opaque_RecoverCredentials() - caller must allocate including envU_len: e.g.:
+   unsigned char resp[OPAQUE_SERVER_SESSION_LEN+envU_len];
    @param [out] sk - the shared secret established between the user & server
    @param [out] sec - the current context necessary for the explicit
    authentication of the user in opaque_UserAuth(). This
@@ -189,7 +189,7 @@ int opaque_CreateCredentialRequest(const uint8_t *pwdU, const uint16_t pwdU_len,
    @return the function returns 0 if everything is correct
  */
 
-int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC_LEN], const uint8_t rec[OPAQUE_USER_RECORD_LEN/*+env_len*/], const Opaque_Ids *ids, const Opaque_App_Infos *infos, uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+env_len*/], uint8_t *sk, uint8_t sec[OPAQUE_SERVER_AUTH_CTX_LEN]);
+int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC_LEN], const uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], const Opaque_Ids *ids, const Opaque_App_Infos *infos, uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+envU_len*/], uint8_t *sk, uint8_t sec[OPAQUE_SERVER_AUTH_CTX_LEN]);
 
 /**
    This is the same function as defined in the paper with the
@@ -224,7 +224,7 @@ int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC
    material not stored directly in the envelope
    @return the function returns 0 if the protocol is executed correctly
 */
-int opaque_RecoverCredentials(const uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+env_len*/], const uint8_t sec[OPAQUE_USER_SESSION_SECRET_LEN/*+pwdU_len*/], const uint8_t *key, const uint16_t key_len, const uint8_t pkS[crypto_scalarmult_BYTES], const Opaque_PkgConfig *cfg, const Opaque_App_Infos *infos, Opaque_Ids *ids, uint8_t *sk, uint8_t authU[crypto_auth_hmacsha256_BYTES], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_RecoverCredentials(const uint8_t resp[OPAQUE_SERVER_SESSION_LEN/*+envU_len*/], const uint8_t sec[OPAQUE_USER_SESSION_SECRET_LEN/*+pwdU_len*/], const uint8_t *key, const uint16_t key_len, const uint8_t pkS[crypto_scalarmult_BYTES], const Opaque_PkgConfig *cfg, const Opaque_App_Infos *infos, Opaque_Ids *ids, uint8_t *sk, uint8_t authU[crypto_auth_hmacsha256_BYTES], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    Explicit User Authentication.
@@ -350,7 +350,7 @@ int opaque_Create1kRegistrationResponse(const uint8_t alpha[crypto_core_ristrett
 
    @return the function returns 0 if everything is correct.
  */
-int opaque_FinalizeRequest(const uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN/*+pwdU_len*/], const uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN], const uint8_t *key, const uint16_t key_len, const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+env_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
+int opaque_FinalizeRequest(const uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN/*+pwdU_len*/], const uint8_t pub[OPAQUE_REGISTER_PUBLIC_LEN], const uint8_t *key, const uint16_t key_len, const Opaque_PkgConfig *cfg, const Opaque_Ids *ids, uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/], uint8_t export_key[crypto_hash_sha256_BYTES]);
 
 /**
    Final Registration step - server adds own info to the record to be stored.
@@ -374,7 +374,7 @@ int opaque_FinalizeRequest(const uint8_t sec[OPAQUE_REGISTER_USER_SEC_LEN/*+pwdU
    account the variable length of idU and idS in case these are
    included in the envelope.
  */
-void opaque_StoreUserRecord(const uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t rec[OPAQUE_USER_RECORD_LEN/*+env_len*/]);
+void opaque_StoreUserRecord(const uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/]);
 
 /**
    Final Registration step Global Server Key Version - server adds own info to the record to be stored.
@@ -405,7 +405,7 @@ void opaque_StoreUserRecord(const uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], uint8
    account the variable length of idU and idS in case these are
    included in the envelope.
  */
-void opaque_Store1kUserRecord(const uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], const uint8_t skS[crypto_scalarmult_SCALARBYTES], uint8_t rec[OPAQUE_USER_RECORD_LEN/*+env_len*/]);
+void opaque_Store1kUserRecord(const uint8_t sec[OPAQUE_REGISTER_SECRET_LEN], const uint8_t skS[crypto_scalarmult_SCALARBYTES], uint8_t rec[OPAQUE_USER_RECORD_LEN/*+envU_len*/]);
 
 /**
    This helper function calculates the length of one part, either the secret

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -16,7 +16,7 @@
 #define OPAQUE_USER_RECORD_LEN (                       \
    /* k_s */ crypto_core_ristretto255_SCALARBYTES+     \
    /* p_s */ crypto_scalarmult_SCALARBYTES+            \
-   /* P_u */ crypto_scalarmult_BYTES+                  \
+   /* pkU */ crypto_scalarmult_BYTES+                  \
    /* pkS */ crypto_scalarmult_BYTES+                  \
    /* env_len */ sizeof(uint32_t))
 

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -28,8 +28,8 @@ typedef struct {
   uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
-  uint32_t env_len;
-  uint8_t envelope[];
+  uint32_t envU_len;
+  uint8_t envU[];
 } __attribute((packed)) Opaque_UserRecord;
 
 static char* type_params[] = {
@@ -211,12 +211,12 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   Opaque_PkgConfig *cfg=(Opaque_PkgConfig *) munit_parameters_get(params, "cfg");
   fprintf(stderr, "cfg sku: %d, pku:%d, pks:%d, idu:%d, ids:%d\n", cfg->skU, cfg->pkU, cfg->pkS, cfg->idU, cfg->idS);
 
-  const uint32_t env_len = opaque_envelope_len(cfg, &ids);
-  unsigned char rec[OPAQUE_USER_RECORD_LEN+env_len];
+  const uint32_t envU_len = opaque_envelope_len(cfg, &ids);
+  unsigned char rec[OPAQUE_USER_RECORD_LEN+envU_len];
   fprintf(stderr,"sizeof(rec): %ld\n",sizeof(rec));
 
   unsigned char sec[OPAQUE_USER_SESSION_SECRET_LEN+pwdU_len], pub[OPAQUE_USER_SESSION_PUBLIC_LEN];
-  unsigned char resp[OPAQUE_SERVER_SESSION_LEN+env_len];
+  unsigned char resp[OPAQUE_SERVER_SESSION_LEN+envU_len];
   uint8_t sk[32];
   uint8_t pk[32];
   uint8_t authU[crypto_auth_hmacsha256_BYTES];

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -234,7 +234,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   }
   uint8_t ctx[OPAQUE_SERVER_AUTH_CTX_LEN]={0};
 
-  uint8_t alpha[crypto_core_ristretto255_BYTES];
+  uint8_t M[crypto_core_ristretto255_BYTES];
   uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len];
 
   uint8_t _skS[crypto_scalarmult_SCALARBYTES], _pkS[crypto_scalarmult_BYTES];
@@ -259,7 +259,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   } else {
     // user initiates:
     fprintf(stderr,"\nopaque_CreateRegistrationRequest\n");
-    if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, alpha)) {
+    if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, M)) {
       fprintf(stderr,"opaque_CreateRegistrationRequest failed.\n");
       return MUNIT_FAIL;
     }
@@ -267,13 +267,13 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
     unsigned char rsec[OPAQUE_REGISTER_SECRET_LEN], rpub[OPAQUE_REGISTER_PUBLIC_LEN];
     if(type==Private1kInit) {
       fprintf(stderr,"\nopaque_Create1kRegistrationResponse\n");
-      if(0!=opaque_Create1kRegistrationResponse(alpha, pkS, rsec, rpub)) {
+      if(0!=opaque_Create1kRegistrationResponse(M, pkS, rsec, rpub)) {
         fprintf(stderr,"opaque_Create1kRegistrationResponse failed.\n");
         return MUNIT_FAIL;
       }
     } else {
       fprintf(stderr,"\nopaque_CreateRegistrationResponse\n");
-      if(0!=opaque_CreateRegistrationResponse(alpha, rsec, rpub)) {
+      if(0!=opaque_CreateRegistrationResponse(M, rsec, rpub)) {
         fprintf(stderr,"opaque_CreateRegistrationResponse failed.\n");
         return MUNIT_FAIL;
       }

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -26,7 +26,7 @@
 typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
   uint8_t p_s[crypto_scalarmult_SCALARBYTES];
-  uint8_t P_u[crypto_scalarmult_BYTES];
+  uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;
   uint8_t envelope[];

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -25,7 +25,7 @@
 
 typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
-  uint8_t p_s[crypto_scalarmult_SCALARBYTES];
+  uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -40,7 +40,7 @@ static char* type_params[] = {
   NULL
 };
 
-static char* pw_params[] = {
+static char* pwdU_params[] = {
   "simple guessable dictionary password",
   "",
   NULL
@@ -177,7 +177,7 @@ static char* cfg_params[]=
 };
 
 static MunitParameterEnum init_params[] = {
-  { "pw", pw_params },
+  { "pwdU", pwdU_params },
   { "key", key_params },
   { "idU", idU_params },
   { "idS", idS_params },
@@ -197,8 +197,8 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   // variant where user registration does not leak secrets to server
   (void)user_data_or_fixture;
   const TestType type = *((const TestType*)munit_parameters_get(params, "type"));
-  const uint8_t *pw=(const uint8_t*) munit_parameters_get(params, "pw");
-  const size_t pw_len=strlen((char*) pw);
+  const uint8_t *pwdU=(const uint8_t*) munit_parameters_get(params, "pwdU");
+  const size_t pwdU_len=strlen((char*) pwdU);
   const uint8_t *key=(const uint8_t*) munit_parameters_get(params, "key");;
   size_t key_len=strlen((char*) key);
   uint8_t export_key[crypto_hash_sha256_BYTES];
@@ -215,7 +215,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   unsigned char rec[OPAQUE_USER_RECORD_LEN+env_len];
   fprintf(stderr,"sizeof(rec): %ld\n",sizeof(rec));
 
-  unsigned char sec[OPAQUE_USER_SESSION_SECRET_LEN+pw_len], pub[OPAQUE_USER_SESSION_PUBLIC_LEN];
+  unsigned char sec[OPAQUE_USER_SESSION_SECRET_LEN+pwdU_len], pub[OPAQUE_USER_SESSION_PUBLIC_LEN];
   unsigned char resp[OPAQUE_SERVER_SESSION_LEN+env_len];
   uint8_t sk[32];
   uint8_t pk[32];
@@ -235,7 +235,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   uint8_t ctx[OPAQUE_SERVER_AUTH_CTX_LEN]={0};
 
   uint8_t alpha[crypto_core_ristretto255_BYTES];
-  uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pw_len];
+  uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len];
 
   uint8_t _skS[crypto_scalarmult_SCALARBYTES], _pkS[crypto_scalarmult_BYTES];
   uint8_t *skS, *pkS;
@@ -252,14 +252,14 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   if(type==ServerInit || type==Server1kInit) {
     // register user
     fprintf(stderr,"\nopaque_Register\n");
-    if(0!=opaque_Register(pw, pw_len, key, key_len, skS, cfg, &ids, rec, export_key)) {
+    if(0!=opaque_Register(pwdU, pwdU_len, key, key_len, skS, cfg, &ids, rec, export_key)) {
       fprintf(stderr,"opaque_Register failed.\n");
       return MUNIT_FAIL;
     }
   } else {
     // user initiates:
     fprintf(stderr,"\nopaque_CreateRegistrationRequest\n");
-    if(0!=opaque_CreateRegistrationRequest(pw, pw_len, usr_ctx, alpha)) {
+    if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, alpha)) {
       fprintf(stderr,"opaque_CreateRegistrationRequest failed.\n");
       return MUNIT_FAIL;
     }
@@ -295,7 +295,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   }
 
   fprintf(stderr,"\nopaque_CreateCredentialRequest\n");
-  opaque_CreateCredentialRequest(pw, pw_len, sec, pub);
+  opaque_CreateCredentialRequest(pwdU, pwdU_len, sec, pub);
   fprintf(stderr,"\nopaque_CreateCredentialResponse\n");
   if(0!=opaque_CreateCredentialResponse(pub, rec, &ids, NULL, resp, sk, ctx)) {
     fprintf(stderr,"opaque_CreateCredentialResponse failed.\n");

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -24,7 +24,7 @@
 #include "../common.h"
 
 typedef struct {
-  uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
+  uint8_t kU[crypto_core_ristretto255_SCALARBYTES];
   uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -46,8 +46,8 @@ static char* pwdU_params[] = {
   NULL
 };
 
-static char* key_params[] = {
-  "some optional key contributed to the opaque protocol",
+static char* info_params[] = {
+  "some optional info contributed to the opaque protocol",
   "",
   NULL
 };
@@ -178,7 +178,7 @@ static char* cfg_params[]=
 
 static MunitParameterEnum init_params[] = {
   { "pwdU", pwdU_params },
-  { "key", key_params },
+  { "info", info_params },
   { "idU", idU_params },
   { "idS", idS_params },
   { "cfg", cfg_params },
@@ -199,8 +199,8 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   const TestType type = *((const TestType*)munit_parameters_get(params, "type"));
   const uint8_t *pwdU=(const uint8_t*) munit_parameters_get(params, "pwdU");
   const size_t pwdU_len=strlen((char*) pwdU);
-  const uint8_t *key=(const uint8_t*) munit_parameters_get(params, "key");;
-  size_t key_len=strlen((char*) key);
+  const uint8_t *info=(const uint8_t*) munit_parameters_get(params, "info");;
+  size_t info_len=strlen((char*) info);
   uint8_t export_key[crypto_hash_sha256_BYTES];
 
   Opaque_Ids ids={0, (uint8_t*) munit_parameters_get(params, "idU"),
@@ -252,7 +252,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   if(type==ServerInit || type==Server1kInit) {
     // register user
     fprintf(stderr,"\nopaque_Register\n");
-    if(0!=opaque_Register(pwdU, pwdU_len, key, key_len, skS, cfg, &ids, rec, export_key)) {
+    if(0!=opaque_Register(pwdU, pwdU_len, info, info_len, skS, cfg, &ids, rec, export_key)) {
       fprintf(stderr,"opaque_Register failed.\n");
       return MUNIT_FAIL;
     }
@@ -280,7 +280,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
     }
     // user commits its secrets
     fprintf(stderr,"\nopaque_FinalizeRequest\n");
-    if(0!=opaque_FinalizeRequest(usr_ctx, rpub, key, key_len, cfg, &ids, rec, export_key)) {
+    if(0!=opaque_FinalizeRequest(usr_ctx, rpub, info, info_len, cfg, &ids, rec, export_key)) {
       fprintf(stderr,"opaque_FinalizeRequest failed.\n");
       return MUNIT_FAIL;
     }
@@ -312,7 +312,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
     pkS = NULL;
   }
 
-  if(0!=opaque_RecoverCredentials(resp, sec, key, key_len, pkS, cfg, NULL, &ids1, pk, authU, export_key)) {
+  if(0!=opaque_RecoverCredentials(resp, sec, info, info_len, pkS, cfg, NULL, &ids1, pk, authU, export_key)) {
     fprintf(stderr,"opaque_RecoverCredentials failed.\n");
     return MUNIT_FAIL;
   }

--- a/src/tests/opaque-munit.c
+++ b/src/tests/opaque-munit.c
@@ -27,7 +27,7 @@ typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
   uint8_t p_s[crypto_scalarmult_SCALARBYTES];
   uint8_t P_u[crypto_scalarmult_BYTES];
-  uint8_t P_s[crypto_scalarmult_BYTES];
+  uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;
   uint8_t envelope[];
 } __attribute((packed)) Opaque_UserRecord;
@@ -306,7 +306,7 @@ MunitResult opaque_test(const MunitParameter params[], void* user_data_or_fixtur
   if(cfg->pkS == NotPackaged) {
     Opaque_UserRecord *_rec = (Opaque_UserRecord *) &rec;
     if(type!=Private1kInit && type!=Server1kInit) {
-      pkS = _rec->P_s;
+      pkS = _rec->pkS;
     }
   } else {
     pkS = NULL;

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -26,8 +26,8 @@ typedef struct {
   uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
-  uint32_t env_len;
-  uint8_t envelope[];
+  uint32_t envU_len;
+  uint8_t envU[];
 } __attribute((packed)) Opaque_UserRecord;
 
 static void _dump(const uint8_t *p, const size_t len, const char* msg) {
@@ -57,8 +57,8 @@ int main(void) {
   };
   _dump((uint8_t*) &cfg,sizeof cfg, "cfg ");
   fprintf(stderr, "cfg sku: %d, pku:%d, pks:%d, idu:%d, ids:%d\n", cfg.skU, cfg.pkU, cfg.pkS, cfg.idU, cfg.idS);
-  const uint32_t env_len = opaque_envelope_len(&cfg, &ids);
-  unsigned char rec[OPAQUE_USER_RECORD_LEN+env_len];
+  const uint32_t envU_len = opaque_envelope_len(&cfg, &ids);
+  unsigned char rec[OPAQUE_USER_RECORD_LEN+envU_len];
   fprintf(stderr, "sizeof(rec): %ld\n",sizeof(rec));
 
   // register user
@@ -73,7 +73,7 @@ int main(void) {
   fprintf(stderr, "\nopaque_CreateCredentialRequest\n");
   opaque_CreateCredentialRequest(pwdU, pwdU_len, sec, pub);
 
-  unsigned char resp[OPAQUE_SERVER_SESSION_LEN+env_len];
+  unsigned char resp[OPAQUE_SERVER_SESSION_LEN+envU_len];
   uint8_t sk[32];
   uint8_t ctx[OPAQUE_SERVER_AUTH_CTX_LEN]={0};
   fprintf(stderr, "\nopaque_CreateCredentialResponse\n");
@@ -138,7 +138,7 @@ int main(void) {
     return 1;
   }
   // user commits its secrets
-  unsigned char rrec[OPAQUE_USER_RECORD_LEN+env_len];
+  unsigned char rrec[OPAQUE_USER_RECORD_LEN+envU_len];
   fprintf(stderr, "\nopaque_FinalizeRequest\n");
   if(0!=opaque_FinalizeRequest(usr_ctx, rpub, key, key_len, &cfg, &ids, rrec, export_key)) {
     fprintf(stderr, "opaque_FinalizeRequest failed.\n");

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -122,18 +122,18 @@ int main(void) {
   fprintf(stderr, "\n\nprivate registration\n\n");
 
   // variant where user registration does not leak secrets to server
-  uint8_t alpha[crypto_core_ristretto255_BYTES];
+  uint8_t M[crypto_core_ristretto255_BYTES];
   uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len];
   // user initiates:
   fprintf(stderr, "\nopaque_CreateRegistrationRequest\n");
-  if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, alpha)) {
+  if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, M)) {
     fprintf(stderr, "opaque_CreateRegistrationRequest failed.\n");
     return 1;
   }
   // server responds
   unsigned char rsec[OPAQUE_REGISTER_SECRET_LEN], rpub[OPAQUE_REGISTER_PUBLIC_LEN];
   fprintf(stderr, "\nopaque_CreateRegistrationResponse\n");
-  if(0!=opaque_CreateRegistrationResponse(alpha, rsec, rpub)) {
+  if(0!=opaque_CreateRegistrationResponse(M, rsec, rpub)) {
     fprintf(stderr, "opaque_CreateRegistrationResponse failed.\n");
     return 1;
   }

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -24,7 +24,7 @@
 typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
   uint8_t p_s[crypto_scalarmult_SCALARBYTES];
-  uint8_t P_u[crypto_scalarmult_BYTES];
+  uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;
   uint8_t envelope[];

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -41,8 +41,8 @@ static void _dump(const uint8_t *p, const size_t len, const char* msg) {
 int main(void) {
   uint8_t pwdU[]="simple guessable dictionary password";
   uint16_t pwdU_len=strlen((char*) pwdU);
-  uint8_t key[]="some optional key contributed to the opaque protocol";
-  uint16_t key_len=strlen((char*) key);
+  uint8_t info[]="some optional key contributed to the opaque protocol";
+  uint16_t info_len=strlen((char*) info);
   uint8_t export_key[crypto_hash_sha256_BYTES];
   uint8_t export_key_x[crypto_hash_sha256_BYTES];
   Opaque_Ids ids={4,(uint8_t*)"user",6,(uint8_t*)"server"};
@@ -63,7 +63,7 @@ int main(void) {
 
   // register user
   fprintf(stderr, "\nopaque_Register\n");
-  if(0!=opaque_Register(pwdU, pwdU_len, key, key_len, NULL, &cfg, &ids, rec, export_key)) {
+  if(0!=opaque_Register(pwdU, pwdU_len, info, info_len, NULL, &cfg, &ids, rec, export_key)) {
     fprintf(stderr, "opaque_Register failed.\n");
     return 1;
   }
@@ -105,7 +105,7 @@ int main(void) {
   }
 
   //Opaque_App_Infos infos;
-  if(0!=opaque_RecoverCredentials(resp, sec, key, key_len, pkS, &cfg, NULL, &ids1, pk, authU, export_key_x)) {
+  if(0!=opaque_RecoverCredentials(resp, sec, info, info_len, pkS, &cfg, NULL, &ids1, pk, authU, export_key_x)) {
     fprintf(stderr, "opaque_RecoverCredentials failed.\n");
     return 1;
   }
@@ -140,7 +140,7 @@ int main(void) {
   // user commits its secrets
   unsigned char rrec[OPAQUE_USER_RECORD_LEN+envU_len];
   fprintf(stderr, "\nopaque_FinalizeRequest\n");
-  if(0!=opaque_FinalizeRequest(usr_ctx, rpub, key, key_len, &cfg, &ids, rrec, export_key)) {
+  if(0!=opaque_FinalizeRequest(usr_ctx, rpub, info, info_len, &cfg, &ids, rrec, export_key)) {
     fprintf(stderr, "opaque_FinalizeRequest failed.\n");
     return 1;
   }
@@ -164,7 +164,7 @@ int main(void) {
   } else {
     pkS = NULL;
   }
-  if(0!=opaque_RecoverCredentials(resp, sec, key, key_len, pkS, &cfg, NULL, &ids1, pk, authU, export_key)) return 1;
+  if(0!=opaque_RecoverCredentials(resp, sec, info, info_len, pkS, &cfg, NULL, &ids1, pk, authU, export_key)) return 1;
   _dump(pk,32,"sk_u: ");
   assert(sodium_memcmp(sk,pk,sizeof sk)==0);
 

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -22,7 +22,7 @@
 #include "../common.h"
 
 typedef struct {
-  uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
+  uint8_t kU[crypto_core_ristretto255_SCALARBYTES];
   uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -23,7 +23,7 @@
 
 typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
-  uint8_t p_s[crypto_scalarmult_SCALARBYTES];
+  uint8_t skS[crypto_scalarmult_SCALARBYTES];
   uint8_t pkU[crypto_scalarmult_BYTES];
   uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -39,8 +39,8 @@ static void _dump(const uint8_t *p, const size_t len, const char* msg) {
 }
 
 int main(void) {
-  uint8_t pw[]="simple guessable dictionary password";
-  uint16_t pw_len=strlen((char*) pw);
+  uint8_t pwdU[]="simple guessable dictionary password";
+  uint16_t pwdU_len=strlen((char*) pwdU);
   uint8_t key[]="some optional key contributed to the opaque protocol";
   uint16_t key_len=strlen((char*) key);
   uint8_t export_key[crypto_hash_sha256_BYTES];
@@ -63,15 +63,15 @@ int main(void) {
 
   // register user
   fprintf(stderr, "\nopaque_Register\n");
-  if(0!=opaque_Register(pw, pw_len, key, key_len, NULL, &cfg, &ids, rec, export_key)) {
+  if(0!=opaque_Register(pwdU, pwdU_len, key, key_len, NULL, &cfg, &ids, rec, export_key)) {
     fprintf(stderr, "opaque_Register failed.\n");
     return 1;
   }
 
   // initiate login
-  unsigned char sec[OPAQUE_USER_SESSION_SECRET_LEN+pw_len], pub[OPAQUE_USER_SESSION_PUBLIC_LEN];
+  unsigned char sec[OPAQUE_USER_SESSION_SECRET_LEN+pwdU_len], pub[OPAQUE_USER_SESSION_PUBLIC_LEN];
   fprintf(stderr, "\nopaque_CreateCredentialRequest\n");
-  opaque_CreateCredentialRequest(pw, pw_len, sec, pub);
+  opaque_CreateCredentialRequest(pwdU, pwdU_len, sec, pub);
 
   unsigned char resp[OPAQUE_SERVER_SESSION_LEN+env_len];
   uint8_t sk[32];
@@ -123,10 +123,10 @@ int main(void) {
 
   // variant where user registration does not leak secrets to server
   uint8_t alpha[crypto_core_ristretto255_BYTES];
-  uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pw_len];
+  uint8_t usr_ctx[OPAQUE_REGISTER_USER_SEC_LEN+pwdU_len];
   // user initiates:
   fprintf(stderr, "\nopaque_CreateRegistrationRequest\n");
-  if(0!=opaque_CreateRegistrationRequest(pw, pw_len, usr_ctx, alpha)) {
+  if(0!=opaque_CreateRegistrationRequest(pwdU, pwdU_len, usr_ctx, alpha)) {
     fprintf(stderr, "opaque_CreateRegistrationRequest failed.\n");
     return 1;
   }
@@ -149,7 +149,7 @@ int main(void) {
   opaque_StoreUserRecord(rsec, rrec);
 
   fprintf(stderr, "\nopaque_CreateCredentialRequest\n");
-  opaque_CreateCredentialRequest(pw, pw_len, sec, pub);
+  opaque_CreateCredentialRequest(pwdU, pwdU_len, sec, pub);
   fprintf(stderr, "\nopaque_CreateCredentialResponse\n");
   if(0!=opaque_CreateCredentialResponse(pub, rrec, &ids, NULL, resp, sk, ctx)) {
     fprintf(stderr, "opaque_CreateCredentialResponse failed.\n");

--- a/src/tests/opaque-test.c
+++ b/src/tests/opaque-test.c
@@ -25,7 +25,7 @@ typedef struct {
   uint8_t k_s[crypto_core_ristretto255_SCALARBYTES];
   uint8_t p_s[crypto_scalarmult_SCALARBYTES];
   uint8_t P_u[crypto_scalarmult_BYTES];
-  uint8_t P_s[crypto_scalarmult_BYTES];
+  uint8_t pkS[crypto_scalarmult_BYTES];
   uint32_t env_len;
   uint8_t envelope[];
 } __attribute((packed)) Opaque_UserRecord;
@@ -101,7 +101,7 @@ int main(void) {
   uint8_t *pkS = NULL;
   if(cfg.pkS == NotPackaged) {
     Opaque_UserRecord *_rec = (Opaque_UserRecord *) &rec;
-    pkS = _rec->P_s;
+    pkS = _rec->pkS;
   }
 
   //Opaque_App_Infos infos;
@@ -160,7 +160,7 @@ int main(void) {
 
   if(cfg.pkS == NotPackaged) {
     Opaque_UserRecord *_rec = (Opaque_UserRecord *) &rec;
-    pkS = _rec->P_s;
+    pkS = _rec->pkS;
   } else {
     pkS = NULL;
   }


### PR DESCRIPTION
This has the benefit of making it easier to compare our implementation with what's proposed in the draft.