### PR TITLE
[docs] note that ids in RecoverCredentials is sometimes an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The API is described in the header file:
 [`src/opaque.h`](https://github.com/stef/libopaque/blob/master/src/opaque.h).
 
 The library implements the OPAQUE protocol with the following deviations from
-the origianl paper:
+the original paper:
 
 0. It does not implement any persistence/lookup functionality.
 1. Instead of HMQV (which is patented), it implements a Triple-DH.
@@ -30,10 +30,9 @@ the origianl paper:
 3. It additionally implements a variant where U secrets never hit S
    unprotected.
 
-For more information, see the IETF CFRG specification at
-https://github.com/cfrg/draft-irtf-cfrg-opaque/blob/master/draft-irtf-cfrg-opaque.md,
-the original paper
-([`doc/opaque.pdf`](https://github.com/stef/libopaque/blob/master/doc/opaque.pdf))
+For more information, see the
+[IETF CFRG specification](https://github.com/cfrg/draft-irtf-cfrg-opaque/blob/master/draft-irtf-cfrg-opaque.md),
+the [original paper](https://github.com/stef/libopaque/blob/master/doc/opaque.pdf)
 and the
 [`src/tests/opaque-test.c`](https://github.com/stef/libopaque/blob/master/src/tests/opaque-test.c)
 example file.

--- a/python/opaque/__init__.py
+++ b/python/opaque/__init__.py
@@ -280,7 +280,7 @@ def CreateCredentialResponse(pub, rec, cfg, ids, infos):
 #  @param [in] cfg - the configuration of the envelope secret and cleartext part
 #  @param [in] infos - various extra (unspecified) protocol information
 #  as recommended by the rfc
-#  @param [out] ids - if ids were packed in the envelope - as given by
+#  @param [in/out] ids - if ids were packed in the envelope - as given by
 #  the cfg param -, they are returned in this struct - if either
 #  cfg.idS or cfg.idU is NotPackaged, then the according value must be
 #  set in this struct before calling opaque_RecoverCredentials

--- a/src/opaque.h
+++ b/src/opaque.h
@@ -203,7 +203,7 @@ int opaque_CreateCredentialResponse(const uint8_t pub[OPAQUE_USER_SESSION_PUBLIC
    @param [in] cfg - the configuration of the envelope secret and cleartext part
    @param [in] infos - various extra (unspecified) protocol information
    as recommended by the rfc
-   @param [out] ids - if ids were packed in the envelope - as given by
+   @param [in/out] ids - if ids were packed in the envelope - as given by
    the cfg param -, they are returned in this struct - if either
    cfg.idS or cfg.idU is NotPackaged, then the according value must be
    set in this struct before calling opaque_RecoverCredentials


### PR DESCRIPTION
It is sometimes an input if cfg.idS or cfg.idU is NotPackaged.