### PR TITLE
[build] add an additional GitHub action to build and test the JS bindings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,17 +39,17 @@ jobs:
 
     - run: |
        cd src
-       sudo apt-get update
-       sudo apt-get install -y libsodium-dev pkgconf # build-essential git
+       sudo apt update
+       sudo apt install -y libsodium-dev pkgconf # build-essential git
        git submodule update --init --recursive tests/munit
        make debug test # Test a debug build.
        make clean all test # Test a production build.
        cd ../python/test
-       sudo apt-get install -y python3-pip
+       sudo apt install -y python3-pip
        pip3 install pysodium
        LD_LIBRARY_PATH="$(pwd)/../../src" PYTHONPATH="$(pwd)/.." python3 simple.py
        cd ../../php7
-       sudo apt-get install -y php php-dev
+       sudo apt install -y php php-dev
        phpize
        LIBOPAQUE_CFLAGS='-I ../src' LIBOPAQUE_LIBS='-lopaque' ./configure
        LD_LIBRARY_PATH=../src TEST_PHP_ARGS=-q make EXTRA_CFLAGS=-I../src EXTRA_LDFLAGS=-L../src test

--- a/.github/workflows/js-bindings.yml
+++ b/.github/workflows/js-bindings.yml
@@ -1,0 +1,30 @@
+name: "Build and test JavaScript bindings"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+
+jobs:
+  build:
+    name: Build and test JavaScript bindings
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - run: |
+       cd js
+       sudo apt install -y libsodium-dev nodejs pkgconf python3-pip uncrustify # build-essential git
+       git clone https://github.com/emscripten-core/emsdk.git # https://emscripten.org/docs/getting_started/downloads.html
+       cd emsdk
+       ./emsdk install 1.40.1
+       ./emsdk activate 1.40.1
+       source ./emsdk_env.sh
+       cd ..
+       make
+       rm -rf emsdk # We do not want to format emsdk.
+       make format test


### PR DESCRIPTION
I also changed from using apt-get to apt in codeql-analysis.yml.

I created a separate action since including the commands in
codeql-analysis.yml significantly increased build time. This was because CodeQL
attempted to examine the Emscripten emsdk files we downloaded.