### PR TITLE
Fix compatibility with specification in regards to `client_mac`

### DIFF
--- a/src/opaque.c
+++ b/src/opaque.c
@@ -113,7 +113,7 @@ static void opaque_hmacsha512(const uint8_t key[OPAQUE_HMAC_SHA512_KEYBYTES],
                               const uint8_t *authenticated, const size_t auth_len,
                               uint8_t mac[OPAQUE_HMAC_SHA512_BYTES]) {
   crypto_auth_hmacsha512_state st;
-  crypto_auth_hmacsha512_init(&st, key, 64);
+  crypto_auth_hmacsha512_init(&st, key, OPAQUE_HMAC_SHA512_KEYBYTES);
   crypto_auth_hmacsha512_update(&st, authenticated, auth_len);
   crypto_auth_hmacsha512_final(&st, mac);
   sodium_memzero(&st,sizeof st);
@@ -1304,10 +1304,10 @@ int opaque_CreateCredentialResponse(const uint8_t _pub[OPAQUE_USER_SESSION_PUBLI
   dump((uint8_t*)preamble, sizeof preamble, "auth preamble");
 #endif
   if(NULL!=authU) {
-    crypto_auth_hmacsha512(authU,                               // out
-                           (uint8_t*)preamble,                  // in
-                           crypto_hash_sha512_BYTES,            // len(in)
-                           keys.km3);                           // key
+    opaque_hmacsha512(keys.km3,                       // key
+                     (uint8_t*)preamble,              // in
+                     crypto_hash_sha512_BYTES,        // len(in)
+                     authU);                          // out
   }
 
   memcpy(sk,keys.sk,sizeof(keys.sk));
@@ -1602,10 +1602,10 @@ int opaque_RecoverCredentials(const uint8_t _resp[OPAQUE_SERVER_SESSION_LEN],
   crypto_hash_sha512_update(&preamble_state, authS, crypto_auth_hmacsha512_BYTES);
   crypto_hash_sha512_final(&preamble_state, (uint8_t *) preamble);
   if(NULL!=authU) {
-    crypto_auth_hmacsha512(authU,                               // out
-                           (uint8_t*)preamble,                  // in
-                           crypto_hash_sha512_BYTES,            // len(in)
-                           keys.km3);                           // key
+    opaque_hmacsha512(keys.km3,                         // key
+                      (uint8_t*)preamble,               // in
+                      crypto_hash_sha512_BYTES,         // len(in)
+                      authU);                           // out
   }
 
   // 2.7. Create KE3 ke3 with client_mac

--- a/src/opaque.c
+++ b/src/opaque.c
@@ -779,7 +779,12 @@ static void calc_preamble(char preamble[crypto_hash_sha512_BYTES],
                             /*nonceS*/OPAQUE_NONCE_BYTES+
                             /*X_s*/crypto_scalarmult_BYTES);
 
-  crypto_hash_sha512_final(state, (uint8_t *) preamble);
+  // We need to copy the state here, because the caller of this function
+  // may re-use it later. After calling the `final` function below,
+  // the passed-in state must not be used again.
+  crypto_hash_sha512_state copied_state;
+  memcpy(&copied_state, state, sizeof(crypto_hash_sha512_state));
+  crypto_hash_sha512_final(&copied_state, (uint8_t *) preamble);
 }
 
 // implements server end of triple-dh


### PR DESCRIPTION
# Summary
This pull request fixes two bugs which lead to an incorrect `client_mac` being calculated: the first bug was about reusing a state parameter which has already been "used up", the second was using an incorrect key length.

# Details

## State parameter reuse
The function `calc_preamble` ends by calling `crypto_hash_sha512_final` on it. After this (according to the [libsodium documentation]) the passed-in state parameter *must not be re-used*. However, in our case the parameter *was* re-used, because the `preamble_state` was used not only for the `server_mac`, but also for the `client_mac`—hence, the SHA512 sum that was calculated before this commit was incorrect.
    
This bug has been fixed by copying the state parameter before passing it to `crypto_hash_sha512_final`. That way, the caller of `calc_preamble` can still use the state and the correct SHA512 sum will be calculated.
    
[libsodium documentation]: https://libsodium.gitbook.io/doc/advanced/sha-2_hash_function#notes

## Incorrect key length
The function `crypto_auth_hmacsha512` was used in `RecoverCredentials` and `CreateCredentialResponse`. This was a problem because the function (i.e., libsodium) uses 32-byte keys by default, while OPAQUE specifies a key length of 64 bytes.
    
The problem has been fixed by replacing this function call with `opaque_hmacsha512`, which uses the correct key length.

# Testing procedure / Background
I noticed these two bugs in the first place because I was using [`opaque-ke`](https://github.com/novifinancial/opaque-ke/) on one side and `libopaque` on the other. Trying to make these two libraries work together was a little difficult due to the relative complexity of pinning down why a certain step failed, but when using the version of `libopaque` from this pull request and the [latest commit of `opaque-ke`](https://github.com/novifinancial/opaque-ke/tree/5a0aef607ccda21ae8a76c687de801632dff2574)[^1], the login flow finally completes successfully.

In other words, it should now be possible to use `libopaque` and `opaque-ke` together without any problems.

(I've also run the tests generated by `make tests` to make sure I didn't break anything.)

[^1]: Before this commit (which is not yet released in the crate itself), `opaque-ke` used a non-standard salt length, which also made it impossible to combine it with `libopaque`.