### PR TITLE
fix(java): length registration record should be OPAQUE_REGISTRATION_RECORD_LEN

### DIFF
--- a/java/jni.c
+++ b/java/jni.c
@@ -396,7 +396,7 @@ static jobject c_finalizeReg(JNIEnv *env, jobject obj, jbyteArray sec_, jbyteArr
   getids(env, ids_, &ids, &gc);
 
   uint8_t export_key[crypto_hash_sha512_BYTES];
-  uint8_t rec[OPAQUE_USER_RECORD_LEN];
+  uint8_t rec[OPAQUE_REGISTRATION_RECORD_LEN];
 
   if(0!=opaque_FinalizeRequest(sec, pub, &ids, rec, export_key)) {
     exception(env,"opaque register() failed...");
@@ -428,7 +428,7 @@ static jbyteArray c_storeRec(JNIEnv *env, jobject obj, jbyteArray sec_, jbyteArr
   sec = (char*) sec_jb;
 
   size_t recU_len= (*env)->GetArrayLength(env, recU_);
-  if(recU_len<=OPAQUE_REGISTRATION_RECORD_LEN) {
+  if(recU_len!=OPAQUE_REGISTRATION_RECORD_LEN) {
     exception(env, "recU has invalid size");
     return NULL;
   }


### PR DESCRIPTION
The record received from opaque_FinalizeRequest and send to opaque_StoreUserRecord has length OPAQUE_REGISTRATION_RECORD_LEN

To give some context:
In our case we use the C solution (using length OPAQUE_REGISTRATION_RECORD_LEN) on client side and the java solution (using length OPAQUE_USER_RECORD_LEN) on backend side, so they expect a different size for the rec.