### PR TITLE
[fix] trying to get mingw build to work - cross-compile to windows.

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -45,7 +45,7 @@ endif
 
 ifdef OPRFHOME
 	OPRFINCDIR=$(OPRFHOME)
-	LDFLAGS+= -L$(OPRFHOME)
+	LDFLAGS+= -L$(OPRFHOME) -L$(OPRFHOME)/noise_xk
 else
 	OPRFINCDIR=/usr/include/oprf
 endif
@@ -79,7 +79,7 @@ asan: all
 
 mingw64: CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -Werror=format-security -Werror=implicit-function-declaration -ftrapv $(DEFINES) -Iwin/libsodium-win64/include/sodium -Iwin/libsodium-win64/include -I$(OPRFINCDIR)
 mingw64: CC=x86_64-w64-mingw32-gcc
-mingw64: LIBS=-L. -lws2_32 -Lwin/libsodium-win64/lib/ -lsodium -Wl,-Bdynamic -loprf
+mingw64: LIBS=-loprf -loprf-noiseXK -L. -lws2_32 -Lwin/libsodium-win64/lib/ -lsodium -Wl,-Bdynamic
 mingw64: INC=-Iwin/libsodium-win64/include/sodium -Iwin/libsodium-win64/include
 mingw64: SOEXT=dll
 mingw64: EXT=.exe

--- a/src/makefile
+++ b/src/makefile
@@ -77,23 +77,14 @@ asan: DEFINES=-DTRACE -DNORANDOM
 asan: LDFLAGS+= -fsanitize=address -static-libasan
 asan: all
 
-mingw64:
-	 CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -Werror=format-security -Werror=implicit-function-declaration -ftrapv $(DEFINES)
-	ifeq ($(ARCH),x86_64)
-	   CFLAGS+=-fcf-protection=full
-	endif
-	ifeq ($(ARCH),parisc64)
-	else ifeq ($(ARCH),parisc64)
-	else
-	   CFLAGS+=-fstack-clash-protection
-	endif
+mingw64: CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -Werror=format-security -Werror=implicit-function-declaration -ftrapv $(DEFINES) -Iwin/libsodium-win64/include/sodium -Iwin/libsodium-win64/include -I$(OPRFINCDIR)
 mingw64: CC=x86_64-w64-mingw32-gcc
-mingw64: LIBS=-L. -lws2_32 -Lwin/libsodium-win64/lib/ -Wl,-Bstatic -lsodium -Wl,-Bdynamic
+mingw64: LIBS=-L. -lws2_32 -Lwin/libsodium-win64/lib/ -lsodium -Wl,-Bdynamic -loprf
 mingw64: INC=-Iwin/libsodium-win64/include/sodium -Iwin/libsodium-win64/include
 mingw64: SOEXT=dll
 mingw64: EXT=.exe
 mingw64: MAKETARGET=mingw
-mingw64: win/libsodium-win64 libopaque.$(SOEXT) tests utils/opaque
+mingw64: win/libsodium-win64 libopaque.$(SOEXT)
 
 TESTS=tests/opaque-test$(EXT) tests/opaque-munit$(EXT)
 ifeq ($(shell test -e $(OPRFHOME)/oprf.c && echo -n yes),yes)


### PR DESCRIPTION
this tries to fix the mingw build, so that a shared dll can be cross compiled. a simple

you need somewhere a liboprf that has already been treated with a `make mingw` and then point the OPRFHOME directory in the correct location, for example when liboprf and libopaque are both in the same root, this would work:

```
OPRFHOME=../../liboprf/src make clean mingw64
```

the result should be a libopaque.dll, which according to `file(1)` is 

```
libopaque.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows, 20 sections
```

for lack of having a windows system myself, testing is up to whoever. feedback, patches very welcome.